### PR TITLE
py313 rebuild

### DIFF
--- a/recipe/loosen_ruamel_bound.patch
+++ b/recipe/loosen_ruamel_bound.patch
@@ -1,0 +1,13 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 8c882dc..8cd8260 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -27,7 +27,7 @@ dependencies = [
+   "conda",
+   "keyring",
+   "requests",
+-  "ruamel.yaml<0.18",
++  "ruamel.yaml<0.19",
+ ]
+ 
+ [project.entry-points.conda]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,9 +38,10 @@ test:
     - conda_auth
   commands:
     - pip check
-    - conda auth --help
-    - conda auth login --help
-    - conda auth logout --help
+    # As with all conda plugins, this must be installed into the base environment
+    #- conda auth --help
+    #- conda auth login --help
+    #- conda auth logout --help
   requires:
     - pip
     - keyrings.alt # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,12 +8,18 @@ package:
 source:
   url: https://github.com/conda-incubator/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
   sha256: c0520d782f99f5c70fcccc3ada84091e75788d49c67cc61586a66b60653cc6f3
+  patches:
+    - loosen_ruamel_bound.patch
+
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   number: 1
   skip: true # [py<38]
 
 requirements:
+  build:
+    - patch # [unix]
+    - m2-patch # [win]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c0520d782f99f5c70fcccc3ada84091e75788d49c67cc61586a66b60653cc6f3
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
-  number: 0
+  number: 1
   skip: true # [py<38]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,10 +38,9 @@ test:
     - conda_auth
   commands:
     - pip check
-    # As with all conda plugins, this must be installed into the base environment
-    #- conda auth --help
-    #- conda auth login --help
-    #- conda auth logout --help
+    - python -m conda auth --help
+    - python -m conda auth login --help
+    - python -m conda auth logout --help
   requires:
     - pip
     - keyrings.alt # [linux]


### PR DESCRIPTION
py313 rebuild

Loosen ruamel bound. Already done on the main branch of conda-auth: https://github.com/conda-incubator/conda-auth/compare/0.2.1...main